### PR TITLE
Add vignettes for ClinicoPathDescriptives

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,3 +65,5 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
+VignetteBuilder: knitr, rmarkdown
+Suggests: knitr, rmarkdown

--- a/vignettes/clinicoPathDescriptives-introduction.Rmd
+++ b/vignettes/clinicoPathDescriptives-introduction.Rmd
@@ -1,0 +1,133 @@
+---
+title: "Getting Started with ClinicoPathDescriptives"
+author: "ClinicoPathDescriptives Team"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Getting Started with ClinicoPathDescriptives}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
+```
+
+# Introduction
+
+`ClinicoPathDescriptives` provides a suite of functions for summarising and visualising clinicopathological data. This vignette showcases the main tools in the package with reproducible examples. The package ships with example data sets `histopathology` and `treatmentResponse` to illustrate typical workflows.
+
+```{r load-package, eval=FALSE}
+# install.packages("ClinicoPathDescriptives")
+library(ClinicoPathDescriptives)
+
+# Example data
+data(histopathology)
+head(histopathology)
+```
+
+# Summaries of Continuous Variables
+
+Use `summarydata()` to obtain descriptive statistics for numeric variables.
+
+```{r summarydata, eval=FALSE}
+summarydata(data = histopathology, vars = vars(Age, TumorSize))
+```
+
+# Summaries of Categorical Variables
+
+`reportcat()` creates frequency tables and counts for categorical variables.
+
+```{r reportcat, eval=FALSE}
+reportcat(data = histopathology, vars = vars(Sex, Grade))
+```
+
+# Cross Tables
+
+Generate cross tabulations with chi-square tests using `crosstable()`.
+
+```{r crosstable, eval=FALSE}
+crosstable(
+  data = histopathology,
+  vars = vars(Sex, Grade),
+  group = "PreinvasiveComponent",
+  sty = "nejm",
+  excl = TRUE
+)
+```
+
+# Table One
+
+`tableone()` produces formatted baseline characteristic tables for reports.
+
+```{r tableone, eval=FALSE}
+tableone(
+  data = histopathology,
+  vars = vars(Sex, PreinvasiveComponent, LVI, PNI, Grade, Age),
+  sty = "t3",
+  excl = TRUE
+)
+```
+
+# Visualisations
+
+The package includes multiple plotting functions to explore data.
+
+## Age Pyramid
+
+```{r agepyramid, eval=FALSE}
+agepyramid(
+  data = histopathology,
+  age = "Age",
+  gender = "Sex",
+  female = "Female"
+)
+```
+
+## Alluvial Diagrams
+
+```{r alluvial, eval=FALSE}
+alluvial(
+  data = histopathology,
+  vars = vars(Grade, LVI, PNI),
+  fill = "first_variable"
+)
+```
+
+## Benford Analysis
+
+```{r benford, eval=FALSE}
+benford(data = histopathology, var = "TumorSize")
+```
+
+## Venn and Variable Trees
+
+```{r venn-vartree, eval=FALSE}
+venn(data = histopathology, vars = vars(LVI, PNI, PreinvasiveComponent))
+vartree(
+  data = histopathology,
+  vars = vars(Grade, LVI, PNI),
+  percvar = "Grade",
+  percvarLevel = "High"
+)
+```
+
+## Waterfall Plots
+
+`waterfall()` visualises tumor response over time.
+
+```{r waterfall, eval=FALSE}
+waterfall(
+  data = treatmentResponse,
+  patientID = "PatientID",
+  responseVar = "Response",
+  timeVar = "Month",
+  inputType = "percentage",
+  showWaterfallPlot = TRUE,
+  showSpiderPlot = TRUE
+)
+```
+
+# Conclusion
+
+These examples demonstrate the versatility of `ClinicoPathDescriptives` for summarising and visualising clinicopathological data. Explore the help pages of each function for additional options and customisation.
+

--- a/vignettes/data-summary.Rmd
+++ b/vignettes/data-summary.Rmd
@@ -1,0 +1,67 @@
+---
+title: "Summarising Clinicopathological Data"
+author: "ClinicoPathDescriptives Team"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Summarising Clinicopathological Data}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
+```
+
+This vignette focuses on the functions that generate tables and textual summaries.
+
+## Continuous Variables
+
+`summarydata()` provides descriptive statistics (mean, median, quartiles) for numeric variables.
+
+```{r cont-sum, eval=FALSE}
+summarydata(
+  data = histopathology,
+  vars = vars(Age, TumorSize)
+)
+```
+
+## Categorical Variables
+
+`reportcat()` summarises categorical variables with counts and percentages.
+
+```{r cat-sum, eval=FALSE}
+reportcat(
+  data = histopathology,
+  vars = vars(Sex, Grade)
+)
+```
+
+## Cross Tables
+
+Use `crosstable()` to create cross tabulations with statistical tests. The `group` argument defines the column variable.
+
+```{r crosstable-vig, eval=FALSE}
+crosstable(
+  data = histopathology,
+  vars = vars(Sex, Grade),
+  group = "PreinvasiveComponent",
+  sty = "nejm",
+  excl = TRUE
+)
+```
+
+## Table One for Publications
+
+`tableone()` creates publication-ready tables of baseline characteristics.
+
+```{r tableone-vig, eval=FALSE}
+tableone(
+  data = histopathology,
+  vars = vars(Sex, PreinvasiveComponent, LVI, PNI, Grade, Age),
+  sty = "t3",
+  excl = TRUE
+)
+```
+
+These functions output results objects that contain tables which can be converted to data frames for further customisation.
+

--- a/vignettes/visualization.Rmd
+++ b/vignettes/visualization.Rmd
@@ -1,0 +1,76 @@
+---
+title: "Visualising Clinicopathological Data"
+author: "ClinicoPathDescriptives Team"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Visualising Clinicopathological Data}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(collapse = TRUE, comment = "#>")
+```
+
+This article covers the visualisation functions available in the package.
+
+## Age Pyramid
+
+```{r vig-agepyramid, eval=FALSE}
+agepyramid(
+  data = histopathology,
+  age = "Age",
+  gender = "Sex",
+  female = "Female"
+)
+```
+
+## Alluvial Diagrams
+
+```{r vig-alluvial, eval=FALSE}
+alluvial(
+  data = histopathology,
+  vars = vars(Grade, LVI, PNI),
+  fill = "first_variable"
+)
+```
+
+## Benford Analysis
+
+```{r vig-benford, eval=FALSE}
+benford(data = histopathology, var = "TumorSize")
+```
+
+## Venn Diagrams
+
+```{r vig-venn, eval=FALSE}
+venn(data = histopathology, vars = vars(LVI, PNI, PreinvasiveComponent))
+```
+
+## Variable Trees
+
+```{r vig-vartree, eval=FALSE}
+vartree(
+  data = histopathology,
+  vars = vars(Grade, LVI, PNI),
+  percvar = "Grade",
+  percvarLevel = "High"
+)
+```
+
+## Waterfall and Spider Plots
+
+```{r vig-waterfall, eval=FALSE}
+waterfall(
+  data = treatmentResponse,
+  patientID = "PatientID",
+  responseVar = "Response",
+  timeVar = "Month",
+  inputType = "percentage",
+  showWaterfallPlot = TRUE,
+  showSpiderPlot = TRUE
+)
+```
+
+These code snippets illustrate the core visualisation tools included in `ClinicoPathDescriptives`.
+


### PR DESCRIPTION
## Summary
- create `vignettes` folder with introductory and example articles
- describe data summarisation functions in a new vignette
- add visualisation vignette covering plotting functions
- enable vignette building by adding Suggests and VignetteBuilder fields

## Testing
- `R CMD check` *(fails: `bash: R: command not found`)*